### PR TITLE
Hotfix/Find a Course MB undefined

### DIFF
--- a/src/form.js
+++ b/src/form.js
@@ -231,7 +231,7 @@ class FormComponent extends HTMLElement {
 		this.removeInlineErrorBlock();
         let form = this.shadow.getElementById('form')
         let formData = form.elements;
-        const ageGroup = formData.age.value.toLowerCase();
+        const ageGroup = getConfig()?.src === 'mb' ? null : formData.age.value.toLowerCase();
         const language = formData.language.value.toLowerCase();
         const radius = formData.radius.value.toLowerCase();
         const startDate = formData.startingin.value.toLowerCase();


### PR DESCRIPTION
There is no "age group" option on the marriage course, therefore, that options is hidden from the UI.
This fix sets the value of that field to `null` in case the request is from The Marriage Course.